### PR TITLE
Move to use conventional commits format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # PR Data Validation Action
 
-A GitHub Action that validates pull requests contain both:
-1. A new file in the `.changelog` directory
-2. A commit with a `Version-Bump:` trailer specifying `patch`, `minor`, or `major`
+A GitHub Action that validates pull requests contain a changelog file in the `.changelog` directory.
 
 ## Usage
 
@@ -37,12 +35,10 @@ jobs:
 | Output | Description |
 |--------|-------------|
 | `changelog-found` | Whether a changelog file was found |
-| `version-bump-found` | Whether a valid version bump trailer was found |
-| `version-bump-type` | The type of version bump (patch, minor, major) |
 
 ## What it checks
 
-### 1. Changelog File
+### Changelog File
 The action checks if the PR includes any new or modified files in the specified changelog directory (`.changelog` by default).
 
 **Example changelog file structure:**
@@ -51,24 +47,6 @@ The action checks if the PR includes any new or modified files in the specified 
 ├── fix-login-bug.md
 ├── add-user-profile.md
 └── breaking-change-api.md
-```
-
-### 2. Version Bump Trailer
-The action looks for a `Version-Bump:` trailer in any of the commit messages in the PR.
-
-**Valid version bump values:**
-- `patch` - for bug fixes and small changes
-- `minor` - for new features (backward compatible)
-- `major` - for breaking changes
-
-**Example commit message:**
-```
-Fix critical authentication bug
-
-This resolves an issue where users couldn't log in
-after password reset.
-
-Version-Bump: patch
 ```
 
 ## Error Messages
@@ -81,16 +59,6 @@ The action provides helpful error messages when validation fails:
    1. Create a new file in the .changelog/ directory
    2. Name it descriptively (e.g., fix-bug-123.md, add-new-feature.md)
    3. Document what changed, why, and any breaking changes
-```
-
-### Missing Version Bump
-```
-🏷️  Please add a Version-Bump trailer to one of your commits:
-   1. Edit your commit message to include one of:
-      - Version-Bump: patch   (for bug fixes)
-      - Version-Bump: minor   (for new features)
-      - Version-Bump: major   (for breaking changes)
-   2. The trailer should be on its own line at the end of the commit message
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PR Data Validation Action
 
-A GitHub Action that validates pull requests contain a changelog file in the `.changelog` directory.
+A GitHub Action that validates pull requests contain a changelog file in the `.changelog` directory with content following the [Conventional Commits](https://www.conventionalcommits.org/) specification.
 
 ## Usage
 
@@ -35,10 +35,11 @@ jobs:
 | Output | Description |
 |--------|-------------|
 | `changelog-found` | Whether a changelog file was found |
+| `changelog-valid` | Whether the changelog content follows conventional commits format |
 
 ## What it checks
 
-### Changelog File
+### 1. Changelog File Presence
 The action checks if the PR includes any new or modified files in the specified changelog directory (`.changelog` by default).
 
 **Example changelog file structure:**
@@ -49,6 +50,32 @@ The action checks if the PR includes any new or modified files in the specified 
 └── breaking-change-api.md
 ```
 
+### 2. Conventional Commits Format
+The content of the changelog file must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. This is validated using [cocogitto](https://github.com/cocogitto/cocogitto).
+
+**Valid changelog content examples:**
+```
+feat: add user authentication
+```
+```
+fix: resolve login timeout issue
+```
+```
+feat(api): add new endpoint for user profiles
+```
+```
+fix(ui): correct button alignment on mobile
+```
+```
+feat!: redesign authentication flow
+```
+
+**Format specification:**
+- `type`: The type of change (e.g., `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`)
+- `scope` (optional): The scope of the change in parentheses (e.g., `(api)`, `(ui)`)
+- `!` (optional): Indicates a breaking change
+- `description`: A short description of the change
+
 ## Error Messages
 
 The action provides helpful error messages when validation fails:
@@ -58,7 +85,15 @@ The action provides helpful error messages when validation fails:
 📝 Please add a changelog file to document your changes:
    1. Create a new file in the .changelog/ directory
    2. Name it descriptively (e.g., fix-bug-123.md, add-new-feature.md)
-   3. Document what changed, why, and any breaking changes
+   3. The content must follow conventional commits format
+```
+
+### Invalid Changelog Format
+When a changelog file is found but its content doesn't follow conventional commits format:
+```
+- ❌ Invalid changelog content format
+  - The changelog content must follow the Conventional Commits specification
+  - Error: <specific error from validator>
 ```
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -1,29 +1,29 @@
-name: 'PR Data Validation'
-description: 'Validates that PRs contain changelog files with conventional commits format'
-author: 'Your Name'
+name: "PR Data Validation"
+description: "Validates that PRs contain changelog files with conventional commits format"
+author: "Your Name"
 
 branding:
-  icon: 'check-circle'
-  color: 'green'
+  icon: "check-circle"
+  color: "green"
 
 inputs:
   token:
-    description: 'GitHub token for API access'
+    description: "GitHub token for API access"
     required: true
     default: ${{ github.token }}
   changelog-dir:
-    description: 'Directory where changelog files should be located'
+    description: "Directory where changelog files should be located"
     required: false
-    default: '.changelog'
+    default: ".changelog"
 
 outputs:
   changelog-found:
-    description: 'Whether a changelog file was found'
+    description: "Whether a changelog file was found"
   changelog-valid:
-    description: 'Whether the changelog content follows conventional commits format'
+    description: "Whether the changelog content follows conventional commits format"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install jq
       shell: bash
@@ -36,7 +36,7 @@ runs:
       run: |
         echo "Installing cocogitto..."
         curl -sSL https://github.com/cocogitto/cocogitto/releases/download/6.5.0/cocogitto-6.5.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /tmp
-        sudo mv /tmp/cog /usr/local/bin/
+        sudo mv /tmp/*/cog /usr/local/bin/
 
     - name: Validate PR Data
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'PR Data Validation'
-description: 'Validates that PRs contain changelog files and version bump trailers'
+description: 'Validates that PRs contain changelog files with conventional commits format'
 author: 'Your Name'
 
 branding:
@@ -19,10 +19,6 @@ inputs:
 outputs:
   changelog-found:
     description: 'Whether a changelog file was found'
-  version-bump-found:
-    description: 'Whether a valid version bump trailer was found'
-  version-bump-type:
-    description: 'The type of version bump (patch, minor, major)'
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,8 @@ inputs:
 outputs:
   changelog-found:
     description: 'Whether a changelog file was found'
+  changelog-valid:
+    description: 'Whether the changelog content follows conventional commits format'
 
 runs:
   using: 'composite'
@@ -28,6 +30,13 @@ runs:
       run: |
         echo "Installing jq..."
         sudo apt-get update && sudo apt-get install -y jq
+
+    - name: Install cocogitto
+      shell: bash
+      run: |
+        echo "Installing cocogitto..."
+        curl -sSL https://github.com/cocogitto/cocogitto/releases/download/6.5.0/cocogitto-6.5.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /tmp
+        sudo mv /tmp/cog /usr/local/bin/
 
     - name: Validate PR Data
       shell: bash

--- a/validate-pr.sh
+++ b/validate-pr.sh
@@ -62,32 +62,82 @@ get_changed_files() {
 }
 
 # Check if changelog file exists in changed files
+# Sets CHANGELOG_FILE global variable with the found file path
 check_changelog_file() {
     local changed_files="$1"
-    local changelog_found=false
+    CHANGELOG_FILE=""
 
     log_info "Checking for changelog files in ${CHANGELOG_DIR}/ directory..."
 
     while IFS= read -r file; do
         if [[ "${file}" == "${CHANGELOG_DIR}/"* ]]; then
             log_info "Found changelog file: ${file}"
-            changelog_found=true
+            CHANGELOG_FILE="${file}"
             break
         fi
     done <<< "${changed_files}"
 
-    if [[ "${changelog_found}" == "false" ]]; then
+    if [[ -z "${CHANGELOG_FILE}" ]]; then
         log_error "No changelog file found in ${CHANGELOG_DIR}/ directory"
         echo ""
         echo "📝 Please add a changelog file to document your changes:"
         echo "   1. Create a new file in the ${CHANGELOG_DIR}/ directory"
         echo "   2. Name it descriptively (e.g., fix-bug-123.md, add-new-feature.md)"
-        echo "   3. Document what changed, why, and any breaking changes"
+        echo "   3. The content must follow conventional commits format"
         echo ""
         return 1
     fi
 
     return 0
+}
+
+# Get the head SHA of the PR for fetching file content
+get_pr_head_sha() {
+    if [[ -f "${GITHUB_EVENT_PATH}" ]]; then
+        jq -r '.pull_request.head.sha' "${GITHUB_EVENT_PATH}"
+    else
+        echo ""
+    fi
+}
+
+# Validate changelog content follows conventional commits format
+# Sets CONTENT_VALIDATION_ERROR global variable with error message if validation fails
+validate_changelog_content() {
+    local file_path="$1"
+    local head_sha="$2"
+    CONTENT_VALIDATION_ERROR=""
+
+    log_info "Validating changelog content format for ${file_path}..."
+
+    # Fetch file content from GitHub API
+    local content_response=$(curl -s \
+        -H "Authorization: token ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github.v3.raw" \
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${file_path}?ref=${head_sha}")
+
+    if [[ -z "${content_response}" ]]; then
+        log_error "Failed to fetch changelog file content"
+        CONTENT_VALIDATION_ERROR="Could not fetch changelog file content from GitHub"
+        return 1
+    fi
+
+    # Write content to temp file
+    local temp_file=$(mktemp)
+    echo "${content_response}" > "${temp_file}"
+
+    # Validate using cog verify
+    log_info "Running conventional commits validation..."
+    local cog_output
+    if cog_output=$(cog verify --file "${temp_file}" 2>&1); then
+        log_info "Changelog content follows conventional commits format"
+        rm -f "${temp_file}"
+        return 0
+    else
+        log_error "Changelog content does not follow conventional commits format"
+        CONTENT_VALIDATION_ERROR="${cog_output}"
+        rm -f "${temp_file}"
+        return 1
+    fi
 }
 
 
@@ -130,33 +180,66 @@ add_review_comment() {
 
 # Generate review comment based on validation results
 generate_review_comment() {
-    local changelog_passed="$1"
+    local changelog_found="$1"
+    local content_valid="$2"
+    local content_error="$3"
 
     local comment_body=""
     local review_event=""
 
-    if [[ "$changelog_passed" == "true" ]]; then
+    if [[ "$changelog_found" == "true" && "$content_valid" == "true" ]]; then
         # All checks passed
         comment_body="## ✅ Changelog Validation Passed
 
 All required data for the changelog validation checks have passed:
 
 - ✅ **Changelog file found** - Changes are documented
+- ✅ **Content format valid** - Follows conventional commits specification
 
 This PR is ready for review! 🚀"
         review_event="COMMENT"
     else
-        # Checks failed
+        # Some checks failed
         comment_body="## ❌ Changelog Validation Failed
 
 The following issues were found with this PR:
 
-- ❌ **Missing changelog file**
+"
+        if [[ "$changelog_found" != "true" ]]; then
+            comment_body+="- ❌ **Missing changelog file**
   - Please add a changelog file to the \`.changelog/\` directory
   - Name it descriptively (e.g., \`fix-bug-123.md\`, \`add-new-feature.md\`)
-  - Document what changed, why, and any breaking changes
+  - The content must follow conventional commits format
 
-Please fix the issues above and push your changes. The validation will run again automatically."
+"
+        else
+            comment_body+="- ✅ **Changelog file found**
+
+"
+        fi
+
+        if [[ "$changelog_found" == "true" && "$content_valid" != "true" ]]; then
+            comment_body+="- ❌ **Invalid changelog content format**
+  - The changelog content must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
+  - Error: \`${content_error}\`
+
+  **Valid format examples:**
+  \`\`\`
+  feat: add user authentication
+  fix: resolve login timeout issue
+  feat(api): add new endpoint for user profiles
+  fix(ui): correct button alignment on mobile
+  feat!: redesign authentication flow (breaking change)
+  \`\`\`
+
+"
+        elif [[ "$changelog_found" == "true" ]]; then
+            comment_body+="- ✅ **Content format valid**
+
+"
+        fi
+
+        comment_body+="Please fix the issues above and push your changes. The validation will run again automatically."
         review_event="REQUEST_CHANGES"
     fi
 
@@ -170,9 +253,10 @@ main() {
     # Check if we're in the right context
     check_pr_context
 
-    # Get PR number
+    # Get PR number and head SHA
     PR_NUMBER=$(get_pr_number)
-    log_info "Validating PR #${PR_NUMBER}"
+    PR_HEAD_SHA=$(get_pr_head_sha)
+    log_info "Validating PR #${PR_NUMBER} (HEAD: ${PR_HEAD_SHA})"
 
     # Get changed files
     CHANGED_FILES=$(get_changed_files "${PR_NUMBER}")
@@ -184,24 +268,31 @@ main() {
     fi
 
     # Check for changelog file
-    changelog_check_passed=true
-    if ! check_changelog_file "${CHANGED_FILES}"; then
-        changelog_check_passed=false
+    changelog_found=false
+    content_valid=false
+    if check_changelog_file "${CHANGED_FILES}"; then
+        changelog_found=true
+
+        # Validate changelog content format
+        if validate_changelog_content "${CHANGELOG_FILE}" "${PR_HEAD_SHA}"; then
+            content_valid=true
+        fi
     fi
 
     # Generate review comment
-    REVIEW_COMMENT=$(generate_review_comment "${changelog_check_passed}")
+    REVIEW_COMMENT=$(generate_review_comment "${changelog_found}" "${content_valid}" "${CONTENT_VALIDATION_ERROR}")
     COMMENT_BODY="${REVIEW_COMMENT%|*}"
     REVIEW_EVENT="${REVIEW_COMMENT#*|}"
 
     # Add review comment to PR
     add_review_comment "${PR_NUMBER}" "${COMMENT_BODY}" "${REVIEW_EVENT}"
 
-    # Set output
-    echo "changelog-found=${changelog_check_passed}" >> $GITHUB_OUTPUT
+    # Set outputs
+    echo "changelog-found=${changelog_found}" >> $GITHUB_OUTPUT
+    echo "changelog-valid=${content_valid}" >> $GITHUB_OUTPUT
 
     # Final validation result
-    if [[ "${changelog_check_passed}" == "true" ]]; then
+    if [[ "${changelog_found}" == "true" && "${content_valid}" == "true" ]]; then
         log_info "✅ All PR data validation checks passed!"
         exit 0
     else

--- a/validate-pr.sh
+++ b/validate-pr.sh
@@ -224,18 +224,18 @@ The following issues were found with this PR:
     fi
 
     if [[ "$changelog_found" == "true" && "$content_valid" != "true" ]]; then
-      REVIEW_COMMENT_BODY+="- ❌ **Invalid changelog content format**
-  - The changelog content must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
-  
-  **Error:**
-  \`\`\`
-  ${content_error}
-  \`\`\`
-  **Valid format examples:**
-  \`\`\`
-  feat: add flying robot support
-  fix: fix a memory link in the walking algorithm 
-  \`\`\`
+      REVIEW_COMMENT_BODY+="- ❌ **Invalid changelog content format** - The changelog content must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
+
+**Error:**
+\`\`\`
+${content_error}
+\`\`\`
+
+**Valid format examples:**
+\`\`\`
+feat: add flying robot support
+fix: fix a memory link in the walking algorithm
+\`\`\`
 
 "
     elif [[ "$changelog_found" == "true" ]]; then

--- a/validate-pr.sh
+++ b/validate-pr.sh
@@ -84,6 +84,11 @@ check_changelog_file() {
         echo "   1. Create a new file in the ${CHANGELOG_DIR}/ directory"
         echo "   2. Name it descriptively (e.g., fix-bug-123.md, add-new-feature.md)"
         echo "   3. The content must follow conventional commits format"
+        echo "      See: https://www.conventionalcommits.org/en/v1.0.0/#summary"
+        echo ""
+        echo "   Example:"
+        echo "      feat: add support for flying robots"
+        echo "      fix: resolve memory leak in the walking algorithm"
         echo ""
         return 1
     fi

--- a/validate-pr.sh
+++ b/validate-pr.sh
@@ -12,190 +12,189 @@ CHANGELOG_DIR="${CHANGELOG_DIR:-.changelog}"
 
 # Helper functions
 log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
+  echo -e "${GREEN}[INFO]${NC} $1"
 }
 
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
+  echo -e "${YELLOW}[WARN]${NC} $1"
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
+  echo -e "${RED}[ERROR]${NC} $1"
 }
 
 # Check if we're in a pull request context
 check_pr_context() {
-    if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
-        log_error "This action should only run on pull request events"
-        exit 1
-    fi
+  if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+    log_error "This action should only run on pull request events"
+    exit 1
+  fi
 }
 
 # Get PR number from GitHub context
 get_pr_number() {
-    if [[ -f "${GITHUB_EVENT_PATH}" ]]; then
-        # Extract PR number directly from the event JSON using jq
-        PR_NUMBER=$(jq -r '.pull_request.number' "${GITHUB_EVENT_PATH}")
+  if [[ -f "${GITHUB_EVENT_PATH}" ]]; then
+    # Extract PR number directly from the event JSON using jq
+    PR_NUMBER=$(jq -r '.pull_request.number' "${GITHUB_EVENT_PATH}")
 
-        if [[ -z "${PR_NUMBER}" || "${PR_NUMBER}" == "null" ]]; then
-            log_error "Could not extract PR number from event data"
-            exit 1
-        fi
-
-        echo "${PR_NUMBER}"
-    else
-        log_error "GITHUB_EVENT_PATH is not set or file does not exist"
-        exit 1
+    if [[ -z "${PR_NUMBER}" || "${PR_NUMBER}" == "null" ]]; then
+      log_error "Could not extract PR number from event data"
+      exit 1
     fi
+
+    echo "${PR_NUMBER}"
+  else
+    log_error "GITHUB_EVENT_PATH is not set or file does not exist"
+    exit 1
+  fi
 }
 
 # Get list of files changed in the PR
 get_changed_files() {
-    local pr_number=$1
+  local pr_number=$1
 
-    # Use GitHub API to get PR files
-    curl -s \
-        -H "Authorization: token ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github.v3+json" \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files" \
-        | jq -r '.[].filename'
+  # Use GitHub API to get PR files
+  curl -s \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files" |
+    jq -r '.[].filename'
 }
 
 # Check if changelog file exists in changed files
 # Sets CHANGELOG_FILE global variable with the found file path
 check_changelog_file() {
-    local changed_files="$1"
-    CHANGELOG_FILE=""
+  local changed_files="$1"
+  CHANGELOG_FILE=""
 
-    log_info "Checking for changelog files in ${CHANGELOG_DIR}/ directory..."
+  log_info "Checking for changelog files in ${CHANGELOG_DIR}/ directory..."
 
-    while IFS= read -r file; do
-        if [[ "${file}" == "${CHANGELOG_DIR}/"* ]]; then
-            log_info "Found changelog file: ${file}"
-            CHANGELOG_FILE="${file}"
-            break
-        fi
-    done <<< "${changed_files}"
-
-    if [[ -z "${CHANGELOG_FILE}" ]]; then
-        log_error "No changelog file found in ${CHANGELOG_DIR}/ directory"
-        echo ""
-        echo "📝 Please add a changelog file to document your changes:"
-        echo "   1. Create a new file in the ${CHANGELOG_DIR}/ directory"
-        echo "   2. Name it descriptively (e.g., fix-bug-123.md, add-new-feature.md)"
-        echo "   3. The content must follow conventional commits format"
-        echo "      See: https://www.conventionalcommits.org/en/v1.0.0/#summary"
-        echo ""
-        echo "   Example:"
-        echo "      feat: add support for flying robots"
-        echo "      fix: resolve memory leak in the walking algorithm"
-        echo ""
-        return 1
+  while IFS= read -r file; do
+    if [[ "${file}" == "${CHANGELOG_DIR}/"* ]]; then
+      log_info "Found changelog file: ${file}"
+      CHANGELOG_FILE="${file}"
+      break
     fi
+  done <<<"${changed_files}"
 
-    return 0
+  if [[ -z "${CHANGELOG_FILE}" ]]; then
+    log_error "No changelog file found in ${CHANGELOG_DIR}/ directory"
+    echo ""
+    echo "📝 Please add a changelog file to document your changes:"
+    echo "   1. Create a new file in the ${CHANGELOG_DIR}/ directory"
+    echo "   2. Name it descriptively (e.g., fix-bug-123.md, add-new-feature.md)"
+    echo "   3. The content must follow conventional commits format"
+    echo "      See: https://www.conventionalcommits.org/en/v1.0.0/#summary"
+    echo ""
+    echo "   Example:"
+    echo "      feat: add support for flying robots"
+    echo "      fix: resolve memory leak in the walking algorithm"
+    echo ""
+    return 1
+  fi
+
+  return 0
 }
 
 # Get the head SHA of the PR for fetching file content
 get_pr_head_sha() {
-    if [[ -f "${GITHUB_EVENT_PATH}" ]]; then
-        jq -r '.pull_request.head.sha' "${GITHUB_EVENT_PATH}"
-    else
-        echo ""
-    fi
+  if [[ -f "${GITHUB_EVENT_PATH}" ]]; then
+    jq -r '.pull_request.head.sha' "${GITHUB_EVENT_PATH}"
+  else
+    echo ""
+  fi
 }
 
 # Validate changelog content follows conventional commits format
 # Sets CONTENT_VALIDATION_ERROR global variable with error message if validation fails
 validate_changelog_content() {
-    local file_path="$1"
-    local head_sha="$2"
-    CONTENT_VALIDATION_ERROR=""
+  local file_path="$1"
+  local head_sha="$2"
+  CONTENT_VALIDATION_ERROR=""
 
-    log_info "Validating changelog content format for ${file_path}..."
+  log_info "Validating changelog content format for ${file_path}..."
 
-    # Fetch file content from GitHub API
-    local content_response=$(curl -s \
-        -H "Authorization: token ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github.v3.raw" \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${file_path}?ref=${head_sha}")
+  # Fetch file content from GitHub API
+  local content_response=$(curl -s \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3.raw" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${file_path}?ref=${head_sha}")
 
-    if [[ -z "${content_response}" ]]; then
-        log_error "Failed to fetch changelog file content"
-        CONTENT_VALIDATION_ERROR="Could not fetch changelog file content from GitHub"
-        return 1
-    fi
+  if [[ -z "${content_response}" ]]; then
+    log_error "Failed to fetch changelog file content"
+    CONTENT_VALIDATION_ERROR="Could not fetch changelog file content from GitHub"
+    return 1
+  fi
 
-    # Write content to temp file
-    local temp_file=$(mktemp)
-    echo "${content_response}" > "${temp_file}"
+  # Write content to temp file
+  local temp_file=$(mktemp)
+  echo "${content_response}" >"${temp_file}"
 
-    # Validate using cog verify
-    log_info "Running conventional commits validation..."
-    local cog_output
-    if cog_output=$(cog verify --file "${temp_file}" 2>&1); then
-        log_info "Changelog content follows conventional commits format"
-        rm -f "${temp_file}"
-        return 0
-    else
-        log_error "Changelog content does not follow conventional commits format"
-        CONTENT_VALIDATION_ERROR="${cog_output}"
-        rm -f "${temp_file}"
-        return 1
-    fi
+  # Validate using cog verify
+  log_info "Running conventional commits validation..."
+  local cog_output
+  if cog_output=$(cog verify --file "${temp_file}" 2>&1); then
+    log_info "Changelog content follows conventional commits format"
+    rm -f "${temp_file}"
+    return 0
+  else
+    log_error "Changelog content does not follow conventional commits format"
+    CONTENT_VALIDATION_ERROR="${cog_output}"
+    rm -f "${temp_file}"
+    return 1
+  fi
 }
-
 
 # Add review comment to PR
 add_review_comment() {
-    local pr_number=$1
-    local body="$2"
-    local event="$3"
+  local pr_number=$1
+  local body="$2"
+  local event="$3"
 
-    log_info "Adding review comment to PR #${pr_number}..."
+  log_info "Adding review comment to PR #${pr_number}..."
 
-    # Create the review payload
-    local review_payload=$(jq -n \
-        --arg body "$body" \
-        --arg event "$event" \
-        '{
+  # Create the review payload
+  local review_payload=$(jq -n \
+    --arg body "$body" \
+    --arg event "$event" \
+    '{
             body: $body,
             event: $event
         }')
 
-    # Submit the review using GitHub API
-    local response=$(curl -s -w "%{http_code}" \
-        -X POST \
-        -H "Authorization: token ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github.v3+json" \
-        -H "Content-Type: application/json" \
-        -d "$review_payload" \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews")
+  # Submit the review using GitHub API
+  local response=$(curl -s -w "%{http_code}" \
+    -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Content-Type: application/json" \
+    -d "$review_payload" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews")
 
-    local http_code="${response: -3}"
-    local response_body="${response%???}"
+  local http_code="${response: -3}"
+  local response_body="${response%???}"
 
-    if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
-        log_info "Successfully added review comment"
-    else
-        log_error "Failed to add review comment. HTTP code: $http_code"
-        log_error "Response: $response_body"
-    fi
+  if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+    log_info "Successfully added review comment"
+  else
+    log_error "Failed to add review comment. HTTP code: $http_code"
+    log_error "Response: $response_body"
+  fi
 }
 
 # Generate review comment based on validation results
 # Sets global variables: REVIEW_COMMENT_BODY and REVIEW_EVENT
 generate_review_comment() {
-    local changelog_found="$1"
-    local content_valid="$2"
-    local content_error="$3"
+  local changelog_found="$1"
+  local content_valid="$2"
+  local content_error="$3"
 
-    REVIEW_COMMENT_BODY=""
-    REVIEW_EVENT=""
+  REVIEW_COMMENT_BODY=""
+  REVIEW_EVENT=""
 
-    if [[ "$changelog_found" == "true" && "$content_valid" == "true" ]]; then
-        # All checks passed
-        REVIEW_COMMENT_BODY="## ✅ Changelog Validation Passed
+  if [[ "$changelog_found" == "true" && "$content_valid" == "true" ]]; then
+    # All checks passed
+    REVIEW_COMMENT_BODY="## ✅ Changelog Validation Passed
 
 All required data for the changelog validation checks have passed:
 
@@ -203,106 +202,106 @@ All required data for the changelog validation checks have passed:
 - ✅ **Content format valid** - Follows conventional commits specification
 
 This PR is ready for review! 🚀"
-        REVIEW_EVENT="COMMENT"
-    else
-        # Some checks failed
-        REVIEW_COMMENT_BODY="## ❌ Changelog Validation Failed
+    REVIEW_EVENT="COMMENT"
+  else
+    # Some checks failed
+    REVIEW_COMMENT_BODY="## ❌ Changelog Validation Failed
 
 The following issues were found with this PR:
 
 "
-        if [[ "$changelog_found" != "true" ]]; then
-            REVIEW_COMMENT_BODY+="- ❌ **Missing changelog file**
+    if [[ "$changelog_found" != "true" ]]; then
+      REVIEW_COMMENT_BODY+="- ❌ **Missing changelog file**
   - Please add a changelog file to the \`.changelog/\` directory
   - Name it descriptively (e.g., \`fix-bug-123.md\`, \`add-new-feature.md\`)
   - The content must follow conventional commits format
 
 "
-        else
-            REVIEW_COMMENT_BODY+="- ✅ **Changelog file found**
+    else
+      REVIEW_COMMENT_BODY+="- ✅ **Changelog file found**
 
 "
-        fi
+    fi
 
-        if [[ "$changelog_found" == "true" && "$content_valid" != "true" ]]; then
-            REVIEW_COMMENT_BODY+="- ❌ **Invalid changelog content format**
+    if [[ "$changelog_found" == "true" && "$content_valid" != "true" ]]; then
+      REVIEW_COMMENT_BODY+="- ❌ **Invalid changelog content format**
   - The changelog content must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
-  - Error: \`${content_error}\`
-
+  
+  **Error:**
+  \`\`\`
+  ${content_error}
+  \`\`\`
   **Valid format examples:**
   \`\`\`
-  feat: add user authentication
-  fix: resolve login timeout issue
-  feat(api): add new endpoint for user profiles
-  fix(ui): correct button alignment on mobile
-  feat!: redesign authentication flow (breaking change)
+  feat: add flying robot support
+  fix: fix a memory link in the walking algorithm 
   \`\`\`
 
 "
-        elif [[ "$changelog_found" == "true" ]]; then
-            REVIEW_COMMENT_BODY+="- ✅ **Content format valid**
+    elif [[ "$changelog_found" == "true" ]]; then
+      REVIEW_COMMENT_BODY+="- ✅ **Content format valid**
 
 "
-        fi
-
-        REVIEW_COMMENT_BODY+="Please fix the issues above and push your changes. The validation will run again automatically."
-        REVIEW_EVENT="REQUEST_CHANGES"
     fi
+
+    REVIEW_COMMENT_BODY+="Please fix the issues above and push your changes. The validation will run again automatically."
+    REVIEW_EVENT="REQUEST_CHANGES"
+  fi
 }
 
 # Main validation function
 main() {
-    log_info "Starting PR data validation..."
+  log_info "Starting PR data validation..."
 
-    # Check if we're in the right context
-    check_pr_context
+  # Check if we're in the right context
+  check_pr_context
 
-    # Get PR number and head SHA
-    PR_NUMBER=$(get_pr_number)
-    PR_HEAD_SHA=$(get_pr_head_sha)
-    log_info "Validating PR #${PR_NUMBER} (HEAD: ${PR_HEAD_SHA})"
+  # Get PR number and head SHA
+  PR_NUMBER=$(get_pr_number)
+  PR_HEAD_SHA=$(get_pr_head_sha)
+  log_info "Validating PR #${PR_NUMBER} (HEAD: ${PR_HEAD_SHA})"
 
-    # Get changed files
-    CHANGED_FILES=$(get_changed_files "${PR_NUMBER}")
-    log_info "Changed files in PR:"
-    echo "${CHANGED_FILES}"
-    if [[ -z "${CHANGED_FILES}" ]]; then
-        log_warn "No files changed in this PR"
-        return 0
+  # Get changed files
+  CHANGED_FILES=$(get_changed_files "${PR_NUMBER}")
+  log_info "Changed files in PR:"
+  echo "${CHANGED_FILES}"
+  if [[ -z "${CHANGED_FILES}" ]]; then
+    log_warn "No files changed in this PR"
+    return 0
+  fi
+
+  # Check for changelog file
+  changelog_found=false
+  content_valid=false
+  if check_changelog_file "${CHANGED_FILES}"; then
+    changelog_found=true
+
+    # Validate changelog content format
+    if validate_changelog_content "${CHANGELOG_FILE}" "${PR_HEAD_SHA}"; then
+      content_valid=true
     fi
+  fi
 
-    # Check for changelog file
-    changelog_found=false
-    content_valid=false
-    if check_changelog_file "${CHANGED_FILES}"; then
-        changelog_found=true
+  # Generate review comment (sets REVIEW_COMMENT_BODY and REVIEW_EVENT globals)
+  generate_review_comment "${changelog_found}" "${content_valid}" "${CONTENT_VALIDATION_ERROR}"
 
-        # Validate changelog content format
-        if validate_changelog_content "${CHANGELOG_FILE}" "${PR_HEAD_SHA}"; then
-            content_valid=true
-        fi
-    fi
+  # Add review comment to PR
+  add_review_comment "${PR_NUMBER}" "${REVIEW_COMMENT_BODY}" "${REVIEW_EVENT}"
 
-    # Generate review comment (sets REVIEW_COMMENT_BODY and REVIEW_EVENT globals)
-    generate_review_comment "${changelog_found}" "${content_valid}" "${CONTENT_VALIDATION_ERROR}"
+  # Set outputs
+  echo "changelog-found=${changelog_found}" >>$GITHUB_OUTPUT
+  echo "changelog-valid=${content_valid}" >>$GITHUB_OUTPUT
 
-    # Add review comment to PR
-    add_review_comment "${PR_NUMBER}" "${REVIEW_COMMENT_BODY}" "${REVIEW_EVENT}"
-
-    # Set outputs
-    echo "changelog-found=${changelog_found}" >> $GITHUB_OUTPUT
-    echo "changelog-valid=${content_valid}" >> $GITHUB_OUTPUT
-
-    # Final validation result
-    if [[ "${changelog_found}" == "true" && "${content_valid}" == "true" ]]; then
-        log_info "✅ All PR data validation checks passed!"
-        exit 0
-    else
-        log_error "❌ PR data validation failed"
-        echo ""
-        echo "Please fix the issues above and push your changes."
-        exit 1
-    fi
+  # Final validation result
+  if [[ "${changelog_found}" == "true" && "${content_valid}" == "true" ]]; then
+    log_info "✅ All PR data validation checks passed!"
+    exit 0
+  else
+    log_error "❌ PR data validation failed"
+    echo ""
+    echo "Please fix the issues above and push your changes."
+    exit 1
+  fi
 }
 
 # Run main function

--- a/validate-pr.sh
+++ b/validate-pr.sh
@@ -184,17 +184,18 @@ add_review_comment() {
 }
 
 # Generate review comment based on validation results
+# Sets global variables: REVIEW_COMMENT_BODY and REVIEW_EVENT
 generate_review_comment() {
     local changelog_found="$1"
     local content_valid="$2"
     local content_error="$3"
 
-    local comment_body=""
-    local review_event=""
+    REVIEW_COMMENT_BODY=""
+    REVIEW_EVENT=""
 
     if [[ "$changelog_found" == "true" && "$content_valid" == "true" ]]; then
         # All checks passed
-        comment_body="## ✅ Changelog Validation Passed
+        REVIEW_COMMENT_BODY="## ✅ Changelog Validation Passed
 
 All required data for the changelog validation checks have passed:
 
@@ -202,29 +203,29 @@ All required data for the changelog validation checks have passed:
 - ✅ **Content format valid** - Follows conventional commits specification
 
 This PR is ready for review! 🚀"
-        review_event="COMMENT"
+        REVIEW_EVENT="COMMENT"
     else
         # Some checks failed
-        comment_body="## ❌ Changelog Validation Failed
+        REVIEW_COMMENT_BODY="## ❌ Changelog Validation Failed
 
 The following issues were found with this PR:
 
 "
         if [[ "$changelog_found" != "true" ]]; then
-            comment_body+="- ❌ **Missing changelog file**
+            REVIEW_COMMENT_BODY+="- ❌ **Missing changelog file**
   - Please add a changelog file to the \`.changelog/\` directory
   - Name it descriptively (e.g., \`fix-bug-123.md\`, \`add-new-feature.md\`)
   - The content must follow conventional commits format
 
 "
         else
-            comment_body+="- ✅ **Changelog file found**
+            REVIEW_COMMENT_BODY+="- ✅ **Changelog file found**
 
 "
         fi
 
         if [[ "$changelog_found" == "true" && "$content_valid" != "true" ]]; then
-            comment_body+="- ❌ **Invalid changelog content format**
+            REVIEW_COMMENT_BODY+="- ❌ **Invalid changelog content format**
   - The changelog content must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
   - Error: \`${content_error}\`
 
@@ -239,16 +240,14 @@ The following issues were found with this PR:
 
 "
         elif [[ "$changelog_found" == "true" ]]; then
-            comment_body+="- ✅ **Content format valid**
+            REVIEW_COMMENT_BODY+="- ✅ **Content format valid**
 
 "
         fi
 
-        comment_body+="Please fix the issues above and push your changes. The validation will run again automatically."
-        review_event="REQUEST_CHANGES"
+        REVIEW_COMMENT_BODY+="Please fix the issues above and push your changes. The validation will run again automatically."
+        REVIEW_EVENT="REQUEST_CHANGES"
     fi
-
-    echo "$comment_body|$review_event"
 }
 
 # Main validation function
@@ -284,13 +283,11 @@ main() {
         fi
     fi
 
-    # Generate review comment
-    REVIEW_COMMENT=$(generate_review_comment "${changelog_found}" "${content_valid}" "${CONTENT_VALIDATION_ERROR}")
-    COMMENT_BODY="${REVIEW_COMMENT%|*}"
-    REVIEW_EVENT="${REVIEW_COMMENT#*|}"
+    # Generate review comment (sets REVIEW_COMMENT_BODY and REVIEW_EVENT globals)
+    generate_review_comment "${changelog_found}" "${content_valid}" "${CONTENT_VALIDATION_ERROR}"
 
     # Add review comment to PR
-    add_review_comment "${PR_NUMBER}" "${COMMENT_BODY}" "${REVIEW_EVENT}"
+    add_review_comment "${PR_NUMBER}" "${REVIEW_COMMENT_BODY}" "${REVIEW_EVENT}"
 
     # Set outputs
     echo "changelog-found=${changelog_found}" >> $GITHUB_OUTPUT

--- a/validate-pr.sh
+++ b/validate-pr.sh
@@ -9,7 +9,6 @@ NC='\033[0m' # No Color
 
 # Configuration
 CHANGELOG_DIR="${CHANGELOG_DIR:-.changelog}"
-REQUIRED_VERSION_BUMPS=("patch" "minor" "major", "none")
 
 # Helper functions
 log_info() {
@@ -91,79 +90,6 @@ check_changelog_file() {
     return 0
 }
 
-# Get commit messages for the PR
-get_pr_commits() {
-    local pr_number=$1
-    log_info "Fetching commits for PR #${pr_number}..."
-
-    # Use GitHub API to get PR commits
-    curl -s \
-        -H "Authorization: token ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github.v3+json" \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/commits" \
-        | jq -r '.[].commit.message'
-}
-
-# Check for version bump trailer in commit messages
-check_version_bump_trailer() {
-    local commit_messages="$1"
-    local version_bump_found=false
-    local version_bump_type=""
-
-    log_info "Checking for Version-Bump trailer in commit messages..."
-
-    while IFS= read -r message; do
-        # Look for Version-Bump: trailer (case insensitive)
-        if echo "${message}" | grep -qi "Version-Bump:"; then
-            # Extract the value after Version-Bump:
-            bump_value=$(echo "${message}" | grep -oiE "Version-Bump:\s*(patch|minor|major|none)" | cut -d':' -f2 | xargs | tr '[:upper:]' '[:lower:]')
-
-            if [[ -n "${bump_value}" ]]; then
-                # Validate the bump value
-                for valid_bump in "${REQUIRED_VERSION_BUMPS[@]}"; do
-                    if [[ "${bump_value}" == "${valid_bump}" ]]; then
-                        log_info "Found valid Version-Bump trailer: ${bump_value}"
-                        version_bump_found=true
-                        version_bump_type="${bump_value}"
-                        break 2
-                    fi
-                done
-            fi
-        fi
-    done <<< "${commit_messages}"
-
-    if [[ "${version_bump_found}" == "false" ]]; then
-        log_error "No valid Version-Bump trailer found in commit messages"
-        echo ""
-        echo "🏷️  Please add a Version-Bump trailer to one of your commits:"
-        echo "   1. Edit your commit message to include one of:"
-        echo "      - Version-Bump: patch   (for bug fixes)"
-        echo "      - Version-Bump: minor   (for new features)"
-        echo "      - Version-Bump: major   (for breaking changes)"
-        echo "      - Version-Bump: none    (for changes not affecting the releasing code)"
-        echo "   2. The trailer should be on its own line at the end of the commit message"
-        echo ""
-        echo "Example commit message:"
-        echo "Fix critical bug in user authentication"
-        echo ""
-        echo "This fixes an issue where users couldn't log in"
-        echo "after password reset."
-        echo ""
-        echo "Version-Bump: patch"
-        echo ""
-        return 1
-    fi
-
-    # Set outputs (only when version bump is found)
-    echo "changelog-found=true" >> $GITHUB_OUTPUT
-    echo "version-bump-found=true" >> $GITHUB_OUTPUT
-    echo "version-bump-type=${version_bump_type}" >> $GITHUB_OUTPUT
-
-    # Export version_bump_type for use in main function
-    export VERSION_BUMP_TYPE="${version_bump_type}"
-
-    return 0
-}
 
 # Add review comment to PR
 add_review_comment() {
@@ -205,65 +131,31 @@ add_review_comment() {
 # Generate review comment based on validation results
 generate_review_comment() {
     local changelog_passed="$1"
-    local version_bump_passed="$2"
-    local version_bump_type="$3"
 
     local comment_body=""
     local review_event=""
 
-    if [[ "$changelog_passed" == "true" && "$version_bump_passed" == "true" ]]; then
+    if [[ "$changelog_passed" == "true" ]]; then
         # All checks passed
         comment_body="## ✅ Changelog Validation Passed
 
 All required data for the changelog validation checks have passed:
 
 - ✅ **Changelog file found** - Changes are documented
-- ✅ **Version bump trailer found** - Type: \`${version_bump_type}\`
 
 This PR is ready for review! 🚀"
         review_event="COMMENT"
     else
-        # Some checks failed
+        # Checks failed
         comment_body="## ❌ Changelog Validation Failed
 
 The following issues were found with this PR:
 
-"
-        if [[ "$changelog_passed" != "true" ]]; then
-            comment_body+="- ❌ **Missing changelog file**
+- ❌ **Missing changelog file**
   - Please add a changelog file to the \`.changelog/\` directory
   - Name it descriptively (e.g., \`fix-bug-123.md\`, \`add-new-feature.md\`)
   - Document what changed, why, and any breaking changes
 
-"
-        else
-            comment_body+="- ✅ **Changelog file found**
-
-"
-        fi
-
-        if [[ "$version_bump_passed" != "true" ]]; then
-            comment_body+="- ❌ **Missing version bump trailer**
-  - Please add a \`Version-Bump:\` trailer to one of your commit messages using \`git commit --trailer 'Version-Bump: <type>'\`
-  - Valid types: \`patch\` (bug fixes), \`minor\` (new features), \`major\` (breaking changes) \`none\` (changes not affecting releases)
-  - Example:
-    \`\`\`
-    Fix critical bug in user authentication
-
-    This fixes an issue where users couldn't log in
-    after password reset.
-
-    Version-Bump: patch
-    \`\`\`
-
-"
-        else
-            comment_body+="- ✅ **Version bump trailer found** - Type: \`${version_bump_type}\`
-
-"
-        fi
-
-        comment_body+="
 Please fix the issues above and push your changes. The validation will run again automatically."
         review_event="REQUEST_CHANGES"
     fi
@@ -297,29 +189,19 @@ main() {
         changelog_check_passed=false
     fi
 
-    # Get commit messages
-    COMMIT_MESSAGES=$(get_pr_commits "${PR_NUMBER}")
-    if [[ -z "${COMMIT_MESSAGES}" ]]; then
-        log_error "No commit messages found for this PR"
-        exit 1
-    fi
-
-    # Check for version bump trailer
-    version_bump_check_passed=true
-    if ! check_version_bump_trailer "${COMMIT_MESSAGES}"; then
-        version_bump_check_passed=false
-    fi
-
     # Generate review comment
-    REVIEW_COMMENT=$(generate_review_comment "${changelog_check_passed}" "${version_bump_check_passed}" "${VERSION_BUMP_TYPE}")
+    REVIEW_COMMENT=$(generate_review_comment "${changelog_check_passed}")
     COMMENT_BODY="${REVIEW_COMMENT%|*}"
     REVIEW_EVENT="${REVIEW_COMMENT#*|}"
 
     # Add review comment to PR
     add_review_comment "${PR_NUMBER}" "${COMMENT_BODY}" "${REVIEW_EVENT}"
 
+    # Set output
+    echo "changelog-found=${changelog_check_passed}" >> $GITHUB_OUTPUT
+
     # Final validation result
-    if [[ "${changelog_check_passed}" == "true" && "${version_bump_check_passed}" == "true" ]]; then
+    if [[ "${changelog_check_passed}" == "true" ]]; then
         log_info "✅ All PR data validation checks passed!"
         exit 0
     else


### PR DESCRIPTION
This pull request updates the PR data validation workflow to require changelog files that follow the Conventional Commits specification, replacing the previous requirement for a version bump trailer in commit messages. The action now installs and uses `cocogitto` to verify changelog content format, updates outputs and error messaging, and removes all logic related to version bump trailers.

* **Removal of Version Bump Trailer Logic**

* All logic related to checking for a `Version-Bump:` trailer in commit messages has been removed from both the documentation and the validation script (`README.md`, `action.yml`, `validate-pr.sh`).

**Changelog Validation Workflow Updates**

* The workflow now validates that a changelog file exists and that its content follows the Conventional Commits format, using [cocogitto](https://github.com/cocogitto/cocogitto?tab=readme-ov-file) for automated verification (`README.md`, `action.yml`, `validate-pr.sh`). 

